### PR TITLE
Dont hide output from browsersync command

### DIFF
--- a/commands/web/browsersync
+++ b/commands/web/browsersync
@@ -7,4 +7,4 @@
 ## ExecRaw: true
 
 echo "Proxying browsersync on ${DDEV_PRIMARY_URL}:3000"
-browser-sync start -c /var/www/html/.ddev/browser-sync.js
+browser-sync start -c /var/www/html/.ddev/browser-sync.js  | grep -v "Access URLs\|--------------------\|Local: http\|External: http"

--- a/commands/web/browsersync
+++ b/commands/web/browsersync
@@ -7,4 +7,4 @@
 ## ExecRaw: true
 
 echo "Proxying browsersync on ${DDEV_PRIMARY_URL}:3000"
-browser-sync start -c /var/www/html/.ddev/browser-sync.js >/dev/null
+browser-sync start -c /var/www/html/.ddev/browser-sync.js


### PR DESCRIPTION
Is there any reason not to show the output from browser-sync?
This makes it more difficult to debug, e.g. see when files are reloaded.