### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ This add-on allows you to run [Browsersync](https://browsersync.io/) through the
 - Install the DDEV Browsersync add-on:
 
 ```shell
+# For DDEV v1.23.5 or above run
+ddev add-on get ddev/ddev-browsersync
+# For earlier versions of DDEV run
 ddev get ddev/ddev-browsersync
+# Then for all versions:
 ddev restart
 ddev browsersync
 ```
@@ -44,9 +48,17 @@ EG.
 
 If you run `ddev browsersync` from a local project and get `Error: unknown command "browsersync" for "ddev"`, run the following to add the command to the project:
 
-  ```shell
-  ddev get ddev/ddev-browsersync
-  ```
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get ddev/ddev-browsersync
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get ddev/ddev-browsersync
+```
 
 Once Browsersync is running, visit `https://<project>.ddev.site:3000` or run `ddev launch :3000` to launch the proxy URL in a web browser.
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.